### PR TITLE
Set custom RPC endpoints without breaking deployer lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .goki/
+Goki.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "solana-sdk",
  "tempfile",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0"
 sha2 = "0.10.0"
 solana-sdk = "1.9.0"
 tempfile = "3.2.0"
+toml = "0.5.8"
 tokio = { version = "1.14.0", features = ["full"] }
 
 [[bin]]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,12 @@
 //! Goki entrypoint
 
-use crate::subcommands;
 use anchor_client::Cluster;
 use anyhow::Result;
 use clap::ArgSettings::NextLineHelp;
 use clap::Parser;
 use std::path::PathBuf;
+
+use crate::subcommands;
 
 const LOCATION_HELP: &str =
     "The location of the Solana program binary. This can be in one of the following formats:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,103 @@
+use anyhow::{Error, Result};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+pub struct WithPath<T> {
+    inner: T,
+    path: PathBuf,
+}
+
+impl<T> WithPath<T> {
+    pub fn new(inner: T, path: PathBuf) -> Self {
+        Self { inner, path }
+    }
+
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> std::convert::AsRef<T> for WithPath<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Config {
+    pub rpc_configs: RPC,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RPC {
+    pub mainnet: String,
+    pub devnet: String,
+    pub testnet: String,
+}
+
+impl Default for RPC {
+    fn default() -> Self {
+        Self {
+            mainnet: "https://api.mainnet-beta.solana.com".to_string(),
+            devnet: "https://api.devnet.solana.com".to_string(),
+            testnet: "https://api.testnet.solana.com".to_string(),
+        }
+    }
+}
+
+impl Config {
+    // Climbs each parent directory until we find an Goki.toml.
+    pub fn discover() -> Result<Option<WithPath<Config>>> {
+        let _cwd = std::env::current_dir()?;
+        let mut cwd_opt = Some(_cwd.as_path());
+
+        while let Some(cwd) = cwd_opt {
+            for f in fs::read_dir(cwd)? {
+                let p = f?.path();
+                if let Some(filename) = p.file_name() {
+                    if filename.to_str() == Some("Goki.toml") {
+                        let cfg = Config::from_path(&p)?;
+                        return Ok(Some(WithPath::new(cfg, p)));
+                    }
+                }
+            }
+
+            cwd_opt = cwd.parent();
+        }
+
+        Ok(None)
+    }
+
+    fn from_path(p: impl AsRef<Path>) -> Result<Self> {
+        let mut cfg_file = File::open(&p)?;
+        let mut cfg_contents = String::new();
+        cfg_file.read_to_string(&mut cfg_contents)?;
+        let cfg = cfg_contents.parse()?;
+
+        Ok(cfg)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct _Config {
+    rpc_configs: Option<RPC>,
+}
+
+impl FromStr for Config {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let cfg: _Config = toml::from_str(s)
+            .map_err(|e| anyhow::format_err!("Unable to deserialize config: {}", e.to_string()))?;
+        Ok(Config {
+            rpc_configs: cfg.rpc_configs.unwrap_or_default(),
+        })
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,8 +33,8 @@ impl<T> std::convert::AsRef<T> for WithPath<T> {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Config {
-    pub rpc_configs: RPC,
-    pub wss_configs: WSS,
+    pub rpc_endpoints: RPC,
+    pub wss_endpoints: WSS,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -114,18 +114,18 @@ impl Config {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct _Config {
-    rpc_configs: Option<RPC>,
-    wss_configs: Option<WSS>,
+    rpc_endpoints: Option<RPC>,
+    wss_endpoints: Option<WSS>,
 }
 
 impl ToString for Config {
     fn to_string(&self) -> String {
         let cfg = _Config {
-            rpc_configs: Some(RPC {
-                ..self.rpc_configs.clone()
+            rpc_endpoints: Some(RPC {
+                ..self.rpc_endpoints.clone()
             }),
-            wss_configs: Some(WSS {
-                ..self.wss_configs.clone()
+            wss_endpoints: Some(WSS {
+                ..self.wss_endpoints.clone()
             }),
         };
 
@@ -140,8 +140,8 @@ impl FromStr for Config {
         let cfg: _Config = toml::from_str(s)
             .map_err(|e| anyhow::format_err!("Unable to deserialize config: {}", e.to_string()))?;
         Ok(Config {
-            rpc_configs: cfg.rpc_configs.unwrap_or_default(),
-            wss_configs: cfg.wss_configs.unwrap_or_default(),
+            rpc_endpoints: cfg.rpc_endpoints.unwrap_or_default(),
+            wss_endpoints: cfg.wss_endpoints.unwrap_or_default(),
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,10 @@ impl Config {
 
         Ok(cfg)
     }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        todo!()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,10 +31,22 @@ impl<T> std::convert::AsRef<T> for WithPath<T> {
     }
 }
 
+impl<T> std::ops::Deref for WithPath<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> std::ops::DerefMut for WithPath<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Config {
     pub rpc_endpoints: RPC,
-    pub wss_endpoints: WSS,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -54,27 +66,6 @@ impl Default for RPC {
             testnet: "https://api.testnet.solana.com".to_string(),
             localnet: "http://127.0.0.1:8899".to_string(),
             debug: "http://34.90.18.145:8899".to_string(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WSS {
-    pub mainnet: String,
-    pub devnet: String,
-    pub testnet: String,
-    pub localnet: String,
-    pub debug: String,
-}
-
-impl Default for WSS {
-    fn default() -> Self {
-        Self {
-            devnet: "wss://api.devnet.solana.com".to_string(),
-            testnet: "wss://api.testnet.solana.com".to_string(),
-            mainnet: "wss://api.mainnet-beta.solana.com".to_string(),
-            localnet: "ws://127.0.0.1:9000".to_string(),
-            debug: "ws://34.90.18.145:9000".to_string(),
         }
     }
 }
@@ -115,7 +106,6 @@ impl Config {
 #[derive(Debug, Serialize, Deserialize)]
 struct _Config {
     rpc_endpoints: Option<RPC>,
-    wss_endpoints: Option<WSS>,
 }
 
 impl ToString for Config {
@@ -123,9 +113,6 @@ impl ToString for Config {
         let cfg = _Config {
             rpc_endpoints: Some(RPC {
                 ..self.rpc_endpoints.clone()
-            }),
-            wss_endpoints: Some(WSS {
-                ..self.wss_endpoints.clone()
             }),
         };
 
@@ -141,7 +128,6 @@ impl FromStr for Config {
             .map_err(|e| anyhow::format_err!("Unable to deserialize config: {}", e.to_string()))?;
         Ok(Config {
             rpc_endpoints: cfg.rpc_endpoints.unwrap_or_default(),
-            wss_endpoints: cfg.wss_endpoints.unwrap_or_default(),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod macros;
 
 pub mod cli;
+pub mod config;
 pub mod location;
 pub mod solana_cmd;
 pub mod subcommands;

--- a/src/solana_cmd.rs
+++ b/src/solana_cmd.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use solana_sdk::pubkey::Pubkey;
 use std::{path::Path, process::Output};
 
-use crate::utils::{exec_command, get_deployer_kp_path};
+use crate::utils::{exec_command, get_cluster_url, get_deployer_kp_path};
 
 /// Sets the buffer authority of a buffer.
 pub fn set_buffer_authority(
@@ -15,7 +15,7 @@ pub fn set_buffer_authority(
     exec_command(
         std::process::Command::new("solana")
             .arg("--url")
-            .arg(&cluster.url())
+            .arg(get_cluster_url(cluster)?)
             .arg("--keypair")
             .arg(deployer_kp)
             .arg("program")
@@ -36,7 +36,7 @@ pub fn set_upgrade_authority(
     exec_command(
         std::process::Command::new("solana")
             .arg("--url")
-            .arg(&cluster.url())
+            .arg(get_cluster_url(cluster)?)
             .arg("--keypair")
             .arg(current_authority)
             .arg("program")
@@ -57,7 +57,7 @@ pub fn write_buffer(
     exec_command(
         std::process::Command::new("solana")
             .arg("--url")
-            .arg(&cluster.url())
+            .arg(get_cluster_url(cluster)?)
             .arg("--keypair")
             .arg(deployer_kp)
             .arg("program")
@@ -74,7 +74,7 @@ pub fn deploy(cluster: &Cluster, program_file: &Path, program_kp_path: &Path) ->
     exec_command(
         std::process::Command::new("solana")
             .arg("--url")
-            .arg(&cluster.url())
+            .arg(get_cluster_url(cluster)?)
             .arg("--keypair")
             .arg(&deployer_kp)
             .arg("program")
@@ -95,7 +95,7 @@ pub fn upgrade(
     exec_command(
         std::process::Command::new("solana")
             .arg("--url")
-            .arg(&cluster.url())
+            .arg(get_cluster_url(cluster)?)
             .arg("--keypair")
             .arg(upgrade_authority_kp)
             .arg("program")

--- a/src/subcommands/airdrop.rs
+++ b/src/subcommands/airdrop.rs
@@ -2,7 +2,7 @@ use anchor_client::Cluster;
 use anyhow::{format_err, Result};
 use std::path::{Path, PathBuf};
 
-use crate::utils::exec_command;
+use crate::utils::{exec_command, get_cluster_url};
 
 pub fn process(cluster: Cluster, amount: &str) -> Result<()> {
     if cluster == Cluster::Mainnet {
@@ -26,7 +26,7 @@ pub fn process(cluster: Cluster, amount: &str) -> Result<()> {
     exec_command(
         std::process::Command::new("solana")
             .arg("--url")
-            .arg(cluster.url())
+            .arg(get_cluster_url(&cluster)?)
             .arg("--keypair")
             .arg(keypair_path)
             .arg("airdrop")

--- a/src/subcommands/init.rs
+++ b/src/subcommands/init.rs
@@ -1,5 +1,3 @@
-use crate::config::*;
-use crate::utils::{exec_command, gen_keypair_file, get_cluster_url};
 use anchor_client::Cluster;
 use anyhow::{format_err, Result};
 use colored::*;
@@ -7,6 +5,9 @@ use solana_sdk::{pubkey::Pubkey, signature::read_keypair_file, signer::Signer};
 use std::fs::File;
 use std::io::Write;
 use std::{fs, path::Path};
+
+use crate::config::Config;
+use crate::utils::{exec_command, gen_keypair_file, get_cluster_url};
 
 pub fn process() -> Result<()> {
     if Config::discover()?.is_some() {

--- a/src/subcommands/init.rs
+++ b/src/subcommands/init.rs
@@ -15,9 +15,9 @@ pub fn process() -> Result<()> {
 
     fs::create_dir_all(".goki/deployers/")?;
 
-    let toml = Config::default();
+    let cfg = Config::default();
     let mut file = File::create("Goki.toml")?;
-    file.write_all(toml.as_bytes())?;
+    file.write_all(cfg.to_string().as_bytes())?;
 
     let mut result: Vec<(Cluster, Pubkey)> = vec![];
 

--- a/src/subcommands/init.rs
+++ b/src/subcommands/init.rs
@@ -1,11 +1,16 @@
+use crate::config::*;
 use crate::utils::{exec_command, gen_keypair_file};
 use anchor_client::Cluster;
-use anyhow::{format_err, Result};
+use anyhow::{anyhow, format_err, Result};
 use colored::*;
 use solana_sdk::{pubkey::Pubkey, signature::read_keypair_file, signer::Signer};
 use std::{fs, path::Path};
 
 pub fn process() -> Result<()> {
+    if Config::discover()?.is_some() {
+        return Err(anyhow!("Workspace already initialized"));
+    }
+
     fs::create_dir_all(".goki/deployers/")?;
 
     let mut result: Vec<(Cluster, Pubkey)> = vec![];

--- a/src/subcommands/init.rs
+++ b/src/subcommands/init.rs
@@ -4,14 +4,20 @@ use anchor_client::Cluster;
 use anyhow::{anyhow, format_err, Result};
 use colored::*;
 use solana_sdk::{pubkey::Pubkey, signature::read_keypair_file, signer::Signer};
+use std::fs::File;
+use std::io::Write;
 use std::{fs, path::Path};
 
 pub fn process() -> Result<()> {
     if Config::discover()?.is_some() {
-        return Err(anyhow!("Workspace already initialized"));
+        return Err(anyhow!("Goki already initialized."));
     }
 
     fs::create_dir_all(".goki/deployers/")?;
+
+    let toml = Config::default();
+    let mut file = File::create("Goki.toml")?;
+    file.write_all(toml.as_bytes())?;
 
     let mut result: Vec<(Cluster, Pubkey)> = vec![];
 

--- a/src/subcommands/pull.rs
+++ b/src/subcommands/pull.rs
@@ -1,11 +1,12 @@
-use crate::location::fetch_program_file;
-use crate::utils::sha256_digest;
 use anyhow::Result;
 use colored::*;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
+
+use crate::location::fetch_program_file;
+use crate::utils::sha256_digest;
 
 pub async fn process(location: &str, out: Option<PathBuf>) -> Result<()> {
     let mut temp_out_file = NamedTempFile::new()?;

--- a/src/subcommands/upload_program_buffer.rs
+++ b/src/subcommands/upload_program_buffer.rs
@@ -2,6 +2,7 @@ use crate::location::fetch_program_file;
 use crate::solana_cmd;
 use crate::utils::exec_command_with_output;
 use crate::utils::gen_new_keypair;
+use crate::utils::get_cluster_url;
 use crate::utils::get_deployer_kp_path;
 use crate::utils::print_header;
 use crate::utils::sha256_digest;
@@ -49,7 +50,7 @@ pub async fn process(cluster: Cluster, location: String, program_id: String) -> 
     let program_info_output = exec_command_with_output(
         std::process::Command::new("solana")
             .arg("--url")
-            .arg(&cluster.url())
+            .arg(get_cluster_url(&cluster)?)
             .arg("--keypair")
             .arg(&deployer_kp_path)
             .arg("program")

--- a/src/subcommands/upload_program_buffer.rs
+++ b/src/subcommands/upload_program_buffer.rs
@@ -1,11 +1,3 @@
-use crate::location::fetch_program_file;
-use crate::solana_cmd;
-use crate::utils::exec_command_with_output;
-use crate::utils::gen_new_keypair;
-use crate::utils::get_cluster_url;
-use crate::utils::get_deployer_kp_path;
-use crate::utils::print_header;
-use crate::utils::sha256_digest;
 use anchor_client::Cluster;
 use anyhow::format_err;
 use anyhow::Result;
@@ -16,6 +8,15 @@ use solana_sdk::signature::Signer;
 use std::fs::File;
 use std::io::BufReader;
 use tempfile::NamedTempFile;
+
+use crate::location::fetch_program_file;
+use crate::solana_cmd;
+use crate::utils::exec_command_with_output;
+use crate::utils::gen_new_keypair;
+use crate::utils::get_cluster_url;
+use crate::utils::get_deployer_kp_path;
+use crate::utils::print_header;
+use crate::utils::sha256_digest;
 
 #[derive(Serialize, Deserialize)]
 struct ProgramInfo {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,10 @@ use std::{
     io::{self, Read, Write},
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
+    string::String,
 };
+
+use crate::config::Config;
 
 /// Generates a keypair and writes it to the [Write].
 pub fn gen_new_keypair<W: Write>(write: &mut W) -> Result<Pubkey> {
@@ -113,4 +116,16 @@ pub fn get_deployer_kp_path(cluster: &Cluster) -> Result<PathBuf> {
         ));
     }
     Ok(deployer_kp_path.clone())
+}
+
+pub fn get_cluster_url(cluster: &Cluster) -> Result<String> {
+    let cfg = Config::discover()?.expect("Goki.toml not found; please run `goki init`");
+    Ok(match cluster {
+        Cluster::Debug => cfg.rpc_endpoints.debug.clone(),
+        Cluster::Testnet => cfg.rpc_endpoints.testnet.clone(),
+        Cluster::Mainnet => cfg.rpc_endpoints.mainnet.clone(),
+        Cluster::Devnet => cfg.rpc_endpoints.devnet.clone(),
+        Cluster::Localnet => cfg.rpc_endpoints.localnet.clone(),
+        _ => panic!("cluster type not supported"),
+    })
 }


### PR DESCRIPTION
Goki.toml
```
[rpc_endpoints]
mainnet = "https://api.mainnet-beta.solana.com"
devnet = "http://127.0.0.1:8899"
# devnet = "https://api.devnet.solana.com"
testnet = "https://api.testnet.solana.com"
localnet = "http://127.0.0.1:8899"
debug = "http://34.90.18.145:8899"
```

Test:
```
✗ ./target/debug/goki init
Goki.toml already exists in workspace
Keypair at devnet already exists: 78fL8TShCDPUQfttpcvU6eejhKsZ6PWomMKuHujajN6a
Keypair at testnet already exists: 7W9oXuPgNopAPkiBQYz2zfAcakheMHnLpnmZ99XU1MDH
Keypair at mainnet already exists: 3neexR9Vanvd7BdDN5EHq3XTsnCvrpC2gZZF77zos3db
Deployers:
devnet: 78fL8TShCDPUQfttpcvU6eejhKsZ6PWomMKuHujajN6a
testnet: 7W9oXuPgNopAPkiBQYz2zfAcakheMHnLpnmZ99XU1MDH
mainnet: 3neexR9Vanvd7BdDN5EHq3XTsnCvrpC2gZZF77zos3db
=> Running command: solana --url http://127.0.0.1:8899 --keypair .goki/deployers/devnet.json airdrop 1
Requesting airdrop of 1 SOL

Signature: 27rtmCcEd27MeupsrM4hsaZNGxxVyKeinQ43Hejvsd32DcegoLJnDAQaxx9TwF12ZqjkE3gB72V1X93TKVo3zaxk

2 SOL
=> Running command: solana --url https://api.testnet.solana.com --keypair .goki/deployers/testnet.json airdrop 1
Requesting airdrop of 1 SOL

Signature: 333RgTuUg4mREa47YzBriGuahTXQf4SWf8XWjtYvBATkSYACvuF1HLEDcuSFaeePd5pV3SjzHNzT8fXULHidamrq

9 SOL
```

```
./target/debug/goki deploy --cluster devnet --location gh:token_signer:GokiProtocol/goki@0.5.2 --program-kp ~/stableswap_deployments/WLPeSwKw4gmcztEq2k72n8XGyrTNXnEEoXAfCqQkwsR.json 

Downloading program code from https://github.com/GokiProtocol/goki/releases/download/v0.5.2/token_signer.so
Program buffer downloaded.
Size (bytes): 146600
SHA256: 0912b4d53ffb786c743af514341cfd2721cd7c72168732dc8d4b4c337c6d44f3
=> Running command: solana --url http://127.0.0.1:8899 --keypair .goki/deployers/devnet.json program deploy --program-id /Users/michaelhuang/stableswap_deployments/WLPeSwKw4gmcztEq2k72n8XGyrTNXnEEoXAfCqQkwsR.json /var/folders/v_/jtpjr4kx5qjgb4q59ghpp88w0000gn/T/nix-shell.T7w10B/.tmpAnh9FP
Program Id: WLPeSwKw4gmcztEq2k72n8XGyrTNXnEEoXAfCqQkwsR

=> Running command: solana --url http://127.0.0.1:8899 --keypair .goki/deployers/devnet.json program set-upgrade-authority WLPeSwKw4gmcztEq2k72n8XGyrTNXnEEoXAfCqQkwsR --new-upgrade-authority 78fL8TShCDPUQfttpcvU6eejhKsZ6PWomMKuHujajN6a
Account Type: Program
Authority: 78fL8TShCDPUQfttpcvU6eejhKsZ6PWomMKuHujajN6a
```